### PR TITLE
Use [[noreturn]] instead of GCC builtin to support MSVC

### DIFF
--- a/src/main/driver/include/drake/common/drake_assert.h
+++ b/src/main/driver/include/drake/common/drake_assert.h
@@ -83,10 +83,10 @@
 namespace drake {
 namespace internal {
 // Abort the program with an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void Abort(const char* condition, const char* func, const char* file, int line);
 // Report an assertion failure; will either Abort(...) or throw.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void AssertionFailed(
     const char* condition, const char* func, const char* file, int line);
 }  // namespace internal

--- a/src/main/driver/include/drake/common/drake_throw.h
+++ b/src/main/driver/include/drake/common/drake_throw.h
@@ -12,7 +12,7 @@
 namespace drake {
 namespace internal {
 // Throw an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void Throw(const char* condition, const char* func, const char* file, int line);
 }  // namespace internal
 }  // namespace drake

--- a/src/test/native/include/drake/common/drake_assert.h
+++ b/src/test/native/include/drake/common/drake_assert.h
@@ -83,10 +83,9 @@
 namespace drake {
 namespace internal {
 // Abort the program with an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void Abort(const char* condition, const char* func, const char* file, int line);
-// Report an assertion failure; will either Abort(...) or throw.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void AssertionFailed(
     const char* condition, const char* func, const char* file, int line);
 }  // namespace internal

--- a/src/test/native/include/drake/common/drake_throw.h
+++ b/src/test/native/include/drake/common/drake_throw.h
@@ -11,8 +11,7 @@
 
 namespace drake {
 namespace internal {
-// Throw an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
+[[noreturn]]
 void Throw(const char* condition, const char* func, const char* file, int line);
 }  // namespace internal
 }  // namespace drake


### PR DESCRIPTION
I didn't actually test this on Windows, but `[[noreturn]]` is standard C++11, so it should work on MSVC. I'll leave actually testing that to the poor sod who tries to compile this on Windows.

As they say, "works on my machine".