### PR TITLE
Add swerve and diff drive+vision Kalman Filter wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/*
 .project
 .classpath
 .idea/*
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "automatic",
-    "files.associations": {
-        "core": "cpp",
-        "functional": "cpp"
-    }
-}

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -1,0 +1,128 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Twist2d;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+
+/**
+ * This class wraps an Extended Kalman Filter to fuse latency-compensated vision
+ * measurements with differential drive encoder measurements. It will correct
+ * for noisy vision measurements and encoder drift. It is intended to be an easy
+ * drop-in for
+ * {@link edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry}; in fact,
+ * if you never call {@link DifferentialDrivePoseEstimator#addVisionMeasurement}
+ * and only call {@link DifferentialDrivePoseEstimator#update} then this will
+ * behave exactly the same as DifferentialDriveOdometry.
+ * <p>
+ * {@link DifferentialDrivePoseEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the
+ * {@link DifferentialDrivePoseEstimator#DifferentialDrivePoseEstimator(Matrix, Matrix, double)
+ * nominal delta time}.)
+ * {@link DifferentialDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it then this class will behave
+ * exactly like regular encoder odometry.
+ * <p>
+ * Our state-space system is:
+ * <p>
+ * x = [[x, y, dtheta]]^T in the field coordinate system.
+ * <p>
+ * u = [[d_l, d_r, dtheta]]^T -- these aren't technically system inputs, but
+ * they make things considerably easier.
+ * <p>
+ * y = [[x, y, theta]]^T
+ */
+public class DifferentialDrivePoseEstimator {
+    private final ExtendedKalmanFilter<N3, N3, N3> mObserver;
+    private final KalmanFilterLatencyCompensator<N3, N3, N3> mLatencyCompensator;
+    /** Seconds */
+    private final double mNominalDt;
+
+    private Rotation2d mGyroOffset;
+    private Rotation2d mPreviousAngle;
+
+    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
+            Matrix<N3, N1> measurementStdDevs) {
+        this(gyroAngle, initialPoseMeters, stateStdDevs, measurementStdDevs, 0.01);
+    }
+
+    public DifferentialDrivePoseEstimator(Rotation2d gyroAngle, Pose2d initialPoseMeters, Matrix<N3, N1> stateStdDevs,
+            Matrix<N3, N1> measurementStdDevs, double nominalDtSeconds) {
+        mNominalDt = nominalDtSeconds;
+
+        mObserver = new ExtendedKalmanFilter<N3, N3, N3>(Nat.N3(), Nat.N3(), Nat.N3(), this::f, (x, u) -> x,
+                stateStdDevs, measurementStdDevs, false, mNominalDt);
+        mLatencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+        mGyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+        mPreviousAngle = initialPoseMeters.getRotation();
+        mObserver.setXhat(poseToVector(initialPoseMeters));
+    }
+
+    private final Matrix<N3, N1> f(Matrix<N3, N1> x, Matrix<N3, N1> u) {
+        // Diff drive forward kinematics:
+        // v_c = (v_l + v_r) / 2
+        double dx = (u.get(0, 0) + u.get(1, 0)) / 2;
+        var newPose = new Pose2d(x.get(0, 0), x.get(1, 0), new Rotation2d(x.get(2, 0)))
+                .exp(new Twist2d(dx, 0.0, u.get(2, 0)));
+
+        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(newPose.getTranslation().getX(),
+                newPose.getTranslation().getY(), x.get(2, 0) + u.get(2, 0));
+    }
+
+    /**
+     * Add a vision measurement to the Extended Kalman Filter. This will correct the
+     * odometry pose estimate while still accounting for measurement noise.
+     * <p>
+     * This method can be called as infrequently as you want, as long as you are
+     * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+     * 
+     * @param visionRobotPose  The pose of the robot as measured by the vision
+     *                         camera.
+     * @param timestampSeconds The timestamp of the vision measurement in seconds
+     *                         since FPGA startup (i.e. the epoch of this timestamp
+     *                         is the same epoch as
+     *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+     *                         Timer.getFPGATimestamp}.) This means that you should
+     *                         use Timer.getFPGATimestamp as your time source in
+     *                         this case.
+     */
+    public void addVisionMeasurement(Pose2d visionRobotPose, double timestampSeconds) {
+        mLatencyCompensator.applyPastMeasurement(mObserver, mNominalDt, poseToVector(visionRobotPose),
+                timestampSeconds);
+    }
+
+    /**
+     * Update the the Extended Kalman Filter using only wheel encoder information.
+     * Note that this should be called every loop (and the correct loop period must
+     * be passed into the constructor of this class.)
+     * 
+     * @param gyroAngle           The current gyro angle.
+     * @param leftDistanceMeters  The distance the left wheel has travelled since
+     *                            the last loop iteration.
+     * @param rightDistanceMeters The distance the left wheel has travelled since
+     *                            the last loop iteration.
+     * @return The estimated pose of the robot.
+     */
+    public Pose2d update(Rotation2d gyroAngle, double leftDistanceMeters, double rightDistanceMeters) {
+        var angle = gyroAngle.plus(mGyroOffset);
+        var u = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(leftDistanceMeters, rightDistanceMeters,
+                angle.minus(mPreviousAngle).getRadians());
+        mPreviousAngle = angle;
+
+        mLatencyCompensator.addObserverState(mObserver, u);
+        mObserver.predict(u, mNominalDt);
+
+        return new Pose2d(mObserver.getXhat(0), mObserver.getXhat(1), new Rotation2d(mObserver.getXhat(2)));
+    }
+
+    private Matrix<N3, N1> poseToVector(Pose2d pose) {
+        return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(pose.getTranslation().getX(), pose.getTranslation().getY(),
+                pose.getRotation().getRadians());
+    }
+}

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilter.java
@@ -13,7 +13,7 @@ import edu.wpi.first.wpiutil.math.numbers.N1;
 import java.util.function.BiFunction;
 
 
-public class ExtendedKalmanFilter<States extends Num, Inputs extends Num, Outputs extends Num> {
+public class ExtendedKalmanFilter<States extends Num, Inputs extends Num, Outputs extends Num> implements KalmanTypeFilter<States, Inputs, Outputs> {
 
     private final boolean m_useRungeKutta;
 
@@ -222,17 +222,17 @@ public class ExtendedKalmanFilter<States extends Num, Inputs extends Num, Output
      * @param y      Measurement vector.
      * @param h      A vector-valued function of x and u that returns the measurement
      *               vector.
-     * @param R      Discrete measurement noise covariance matrix.
+     * @param discR  Discrete measurement noise covariance matrix.
      */
     public <Rows extends Num> void correct(
             Nat<Rows> rows, Matrix<Inputs, N1> u,
             Matrix<Rows, N1> y,
             BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<Rows, N1>> h,
-            Matrix<Rows, Rows> R
+            Matrix<Rows, Rows> discR
     ) {
         final var C = NumericalJacobian.numericalJacobianX(rows, m_states, h, m_xHat, u);
 
-        final var S = C.times(m_P).times(C.transpose()).plus(R);
+        final var S = C.times(m_P).times(C.transpose()).plus(discR);
 
         // We want to put K = PC^T S^-1 into Ax = b form so we can solve it more
         // efficiently.

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilter.java
@@ -29,7 +29,7 @@ import org.ejml.simple.SimpleMatrix;
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
 public class KalmanFilter<States extends Num, Inputs extends Num,
-        Outputs extends Num> {
+        Outputs extends Num> implements KalmanTypeFilter<States, Inputs, Outputs> {
 
     /**
      * The states of the system.
@@ -123,6 +123,15 @@ public class KalmanFilter<States extends Num, Inputs extends Num,
      */
     public Matrix<States, States> getP() {
         return m_P;
+    }
+
+    /**
+     * Sets the entire error covariance matrix P.
+     *
+     * @param newP The new value of P to use.
+     */
+    public void setP(Matrix<States, States> newP) {
+        m_P = newP;
     }
 
     /**

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -1,0 +1,87 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+class KalmanFilterLatencyCompensator<States extends Num, Inputs extends Num, Outputs extends Num>
+{
+    private final static int k_maxPastObserverStates = 300;
+
+    private final TreeMap<Double, ObserverState> m_pastObserverStates;
+
+    public KalmanFilterLatencyCompensator()
+    {
+        m_pastObserverStates = new TreeMap<>();
+    }
+
+    public void addObserverState(KalmanTypeFilter<States, Inputs, Outputs> observer, Matrix<Inputs, N1> u)
+    {
+        m_pastObserverStates.put(Timer.getFPGATimestamp(), new ObserverState(observer, u));
+        
+        if (m_pastObserverStates.size() > k_maxPastObserverStates) {
+            m_pastObserverStates.remove(m_pastObserverStates.firstKey());
+        }
+    }
+
+    public void applyPastMeasurement(
+        KalmanTypeFilter<States, Inputs, Outputs> observer,
+        double dtSeconds,
+        Matrix<Outputs, N1> y,
+        double timestampSeconds
+    ) {
+        var low = m_pastObserverStates.floorEntry(timestampSeconds);
+        var high = m_pastObserverStates.ceilingEntry(timestampSeconds);
+
+        // Find the entry closest in time to timestampSeconds
+        Map.Entry<Double, ObserverState> closestEntry = null;
+        if (low != null && high != null) {
+            closestEntry = Math.abs(timestampSeconds - low.getKey()) < Math.abs(timestampSeconds - high.getKey()) ? low
+                    : high;
+        } else {
+            closestEntry = low != null ? low : high;
+        }
+        if (closestEntry == null) {
+            // State map was empty, which means that we got a past measurement right at startup
+            // The only thing we can really do is ignore the measurement
+            return;
+        }
+
+        var tailMap = m_pastObserverStates.tailMap(closestEntry.getKey(), true);
+        for (var st : tailMap.values()) {
+            if (y != null) {
+                observer.setP(st.errorCovariances);
+                observer.setXhat(st.xHat);
+                // Note that we correct the observer with inputs closest in time to the measurement
+                // This makes the assumption that the dt is small enough that the difference between the measurement time and the time that the inputs were captured at is very small
+                observer.correct(st.inputs, y);
+            }
+            observer.predict(st.inputs, dtSeconds);
+
+            y = null;
+        }
+    }
+
+    /**
+     * This class contains all the information about our observer 
+     */
+    public class ObserverState {
+        public final Matrix<States, N1> xHat;
+        public final Matrix<States, States> errorCovariances;
+        public final Matrix<Inputs, N1> inputs;
+
+        private ObserverState(KalmanTypeFilter<States, Inputs, Outputs> observer, Matrix<Inputs, N1> u) {
+            this.xHat = observer.getXhat();
+            this.errorCovariances = observer.getP();
+
+            inputs = u;
+        }
+    }
+}

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanTypeFilter.java
@@ -1,0 +1,28 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+interface KalmanTypeFilter<States extends Num, Inputs extends Num, Outputs extends Num>
+{
+    Matrix<States, States> getP();
+
+    double getP(int i, int j);
+
+    void setP(Matrix<States, States> newP);
+
+    Matrix<States, N1> getXhat();
+
+    double getXhat(int i);
+
+    void setXhat(Matrix<States, N1> xHat);
+    
+    void setXhat(int i, double value);
+
+    void reset();
+    
+    void predict(Matrix<Inputs, N1> u, double dtSeconds);
+
+    void correct(Matrix<Inputs, N1> u, Matrix<Outputs, N1> y);
+}

--- a/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
+++ b/src/main/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilter.java
@@ -13,7 +13,7 @@ import java.util.function.BiFunction;
 
 
 public class UnscentedKalmanFilter<States extends Num, Inputs extends Num,
-        Outputs extends Num> {
+        Outputs extends Num> implements KalmanTypeFilter<States, Inputs, Outputs> {
 
     private final BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> m_f;
     private final BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<Outputs, N1>> m_h;
@@ -96,6 +96,73 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num,
     }
 
     /**
+     * Returns the error covariance matrix P.
+     *
+     * @return the error covariance matrix P.
+     */
+    public Matrix<States, States> getP() {
+        return m_P;
+    }
+
+    /**
+     * Sets the entire error covariance matrix P.
+     *
+     * @param newP The new value of P to use.
+     */
+    public void setP(Matrix<States, States> newP) {
+        m_P = newP;
+    }
+
+    /**
+     * Returns an element of the error covariance matrix P.
+     *
+     * @param i Row of P.
+     * @param j Column of P.
+     * @return the value of the error covariance matrix P at (i, j).
+     */
+    public double getP(int i, int j) {
+        return m_P.get(i, j);
+    }
+
+    /**
+     * Returns the state estimate x-hat.
+     *
+     * @return the state estimate x-hat.
+     */
+    public Matrix<States, N1> getXhat() {
+        return m_xHat;
+    }
+
+    /**
+     * Set initial state estimate x-hat.
+     *
+     * @param xHat The state estimate x-hat.
+     */
+    public void setXhat(Matrix<States, N1> xHat) {
+        m_xHat = xHat;
+    }
+
+    /**
+     * Returns an element of the state estimate x-hat.
+     *
+     * @param i Row of x-hat.
+     * @return the value of the state estimate x-hat at i.
+     */
+    public double getXhat(int i) {
+        return m_xHat.get(i, 0);
+    }
+
+    /**
+     * Set an element of the initial state estimate x-hat.
+     *
+     * @param i     Row of x-hat.
+     * @param value Value for element of x-hat.
+     */
+    public void setXhat(int i, double value) {
+        m_xHat.set(i, 0, value);
+    }
+
+    /**
      * Resets the observer.
      */
     public void reset() {
@@ -130,6 +197,11 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num,
 
     }
 
+    @Override
+    public void correct(Matrix<Inputs, N1> u, Matrix<Outputs, N1> y) {
+        correct(u, y, m_h, m_R);
+    }
+
     /**
      * Correct the state estimate x-hat using the measurements in y.
      * <p>
@@ -143,7 +215,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num,
      *          the measurement vector.
      * @param R Measurement noise covariance matrix.
      */
-    public void Correct(
+    public void correct(
             Matrix<Inputs, N1> u,
             Matrix<Outputs, N1> y,
             BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<Outputs, N1>> h,

--- a/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -1,0 +1,111 @@
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChartBuilder;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Transform2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+
+public class DifferentialDrivePoseEstimatorTest {
+    @Test
+    public void testAccuracy() {
+        var estimator = new DifferentialDrivePoseEstimator(new Rotation2d(), new Pose2d(),
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.002, 0.002, 0.001),
+                new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.05, 0.05, 0.001));
+
+        var traj = TrajectoryGenerator.generateTrajectory(
+                List.of(new Pose2d(), new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                        new Pose2d(23, 23, Rotation2d.fromDegrees(173)), new Pose2d(54, 54, new Rotation2d())),
+                new TrajectoryConfig(0.5, 2));
+
+        var kinematics = new DifferentialDriveKinematics(1);
+        var rand = new Random();
+
+        List<Double> trajXs = new ArrayList<>();
+        List<Double> trajYs = new ArrayList<>();
+        List<Double> observerXs = new ArrayList<>();
+        List<Double> observerYs = new ArrayList<>();
+        List<Double> visionXs = new ArrayList<>();
+        List<Double> visionYs = new ArrayList<>();
+
+        final double dt = 0.01;
+        double t = 0.0;
+
+        final double visionUpdateRate = 0.1;
+        Pose2d lastVisionPose = null;
+        double lastVisionUpdateRealTimestamp = Double.NEGATIVE_INFINITY;
+        double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+        double maxError = Double.NEGATIVE_INFINITY;
+        double errorSum = 0;
+        while (t <= traj.getTotalTimeSeconds()) {
+            var groundtruthState = traj.sample(t);
+            var input = kinematics.toWheelSpeeds(new ChassisSpeeds(groundtruthState.velocityMetersPerSecond, 0.0,
+                    // ds/dt * dtheta/ds = dtheta/dt
+                    groundtruthState.velocityMetersPerSecond * groundtruthState.curvatureRadPerMeter));
+
+            if (lastVisionUpdateTime + visionUpdateRate < t) {
+                if (lastVisionPose != null) {
+                    estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateRealTimestamp);
+                }
+                lastVisionPose = groundtruthState.poseMeters.transformBy(
+                        new Transform2d(new Translation2d(rand.nextGaussian() * 0.05, rand.nextGaussian() * 0.05),
+                                new Rotation2d(rand.nextGaussian() * 0.001)));
+                lastVisionUpdateRealTimestamp = Timer.getFPGATimestamp();
+                lastVisionUpdateTime = t;
+
+                visionXs.add(lastVisionPose.getTranslation().getX());
+                visionYs.add(lastVisionPose.getTranslation().getY());
+            }
+
+            var xHat = estimator.update(
+                    groundtruthState.poseMeters.getRotation().plus(new Rotation2d(rand.nextGaussian() * 0.001)),
+                    input.leftMetersPerSecond * dt + rand.nextGaussian() * 0.002,
+                    input.rightMetersPerSecond * dt + rand.nextGaussian() * 0.002);
+
+            double error = groundtruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+            if (error > maxError) {
+                maxError = error;
+            }
+            errorSum += error;
+
+            trajXs.add(groundtruthState.poseMeters.getTranslation().getX());
+            trajYs.add(groundtruthState.poseMeters.getTranslation().getY());
+            observerXs.add(xHat.getTranslation().getX());
+            observerYs.add(xHat.getTranslation().getY());
+
+            t += dt;
+        }
+
+        var chartBuilder = new XYChartBuilder();
+        chartBuilder.title = "The Magic of Sensor Fusion";
+        var chart = chartBuilder.build();
+
+        chart.addSeries("Vision", visionXs, visionYs);
+        chart.addSeries("Trajectory", trajXs, trajYs);
+        chart.addSeries("xHat", observerXs, observerYs);
+
+        System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
+        System.out.println("Max error (meters):  " + maxError);
+
+        new SwingWrapper<>(chart).displayChart();
+        try {
+            Thread.sleep(1000000000);
+        } catch (InterruptedException e) {
+        }
+    }
+}

--- a/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -102,10 +102,10 @@ public class DifferentialDrivePoseEstimatorTest {
         System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
         System.out.println("Max error (meters):  " + maxError);
 
-        new SwingWrapper<>(chart).displayChart();
-        try {
-            Thread.sleep(1000000000);
-        } catch (InterruptedException e) {
-        }
+        // new SwingWrapper<>(chart).displayChart();
+        // try {
+        //     Thread.sleep(1000000000);
+        // } catch (InterruptedException e) {
+        // }
     }
 }

--- a/src/test/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilterTest.java
+++ b/src/test/java/edu/wpi/first/wpilibj/estimator/ExtendedKalmanFilterTest.java
@@ -286,14 +286,10 @@ public class ExtendedKalmanFilterTest {
         System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
         System.out.println("Max error (meters):  " + maxError);
 
-//        new SwingWrapper<>(chart).displayChart();
-//        try {
-//            Thread.sleep(1000000000);
-//        } catch (InterruptedException e) {
-//        }
-    }
-
-    private Transform2d getRandomTransform(double xStdDev, double yStdDev, double thetaStdDev, Random rand) {
-        return new Transform2d(new Translation2d(rand.nextGaussian() * xStdDev, rand.nextGaussian() * yStdDev), new Rotation2d(rand.nextGaussian() * thetaStdDev));
+        // new SwingWrapper<>(chart).displayChart();
+        // try {
+        //     Thread.sleep(1000000000);
+        // } catch (InterruptedException e) {
+        // }
     }
 }


### PR DESCRIPTION
This adds easy-to-use latency compensated (Extended) Kalman Filter wrappers that fuse encoder and vision information. This is a major part of making the new sensor fusion stuff usable by the average team.